### PR TITLE
ci(bambulab-timelapse-downloader): migrate to tag-gated release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,30 +2,26 @@ name: CI/CD Pipeline
 
 on:
   push:
-    branches: [ main, master ]
+    branches: [ master ]
+    tags: [ 'v*' ]
   pull_request:
-    branches: [ main, master ]
-  pull_request_target:
-    branches: [ main, master ]
-  release:
-    types: [ published ]
+    branches: [ master ]
   workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+  contents: write
+  packages: write
+  security-events: write
+  actions: read
+
 jobs:
   ci-cd:
     name: Python CI/CD Pipeline
     uses: mac-lucky/actions-shared-workflows/.github/workflows/python-cicd-reusable.yml@master
-    # Add permissions for dependabot PRs
-    permissions:
-      contents: read
-      packages: write
-      security-events: write
-      actions: read
-      pull-requests: read
     with:
       # Application configuration
       app_name: "bambulab-timelapse-downloader"
@@ -33,7 +29,7 @@ jobs:
       ghcr_image: "ghcr.io/mac-lucky/bambulab-timelapse-downloader"
 
       # Build configuration
-      dockerfile_path: "./dockerfile"
+      dockerfile_path: "./Dockerfile"
       build_context: "."
 
       # Package manager
@@ -50,8 +46,6 @@ jobs:
       enable_code_analysis: true
 
       # Deployment
-      enable_auto_version: true
-      push_on_main: true
       push_to_dockerhub: true
     secrets:
       DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
-# Build stage - Use official uv image for fast dependency installation
-FROM ghcr.io/astral-sh/uv:python3.12-alpine AS builder
+# Build stage - Use official uv image for fast dependency installation.
+# Pinned to an exact uv release: the floating python3.12-alpine tag moves
+# underneath the resolver and would change what gets installed between builds.
+FROM ghcr.io/astral-sh/uv:0.11.29-python3.12-alpine AS builder
 
 # Install build dependencies
 RUN apk add --no-cache \
@@ -19,8 +21,8 @@ COPY timelapse_downloader.py .
 RUN uv venv /venv && \
     uv pip install --python /venv/bin/python -r pyproject.toml
 
-# Runtime stage - Use official uv image for smaller size
-FROM ghcr.io/astral-sh/uv:python3.12-alpine
+# Runtime stage - same pinned image as the builder, for a matching Python build
+FROM ghcr.io/astral-sh/uv:0.11.29-python3.12-alpine
 
 # Install runtime dependencies (ffmpeg needed for moviepy)
 RUN apk add --no-cache ffmpeg

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>mac-lucky/actions-shared-workflows"]
+}


### PR DESCRIPTION
Adopts the new shared-workflow contract: publish only happens on v* tag pushes (amd64+arm64, GHCR + Docker Hub, generated release notes, SBOM). Renames dockerfile to Dockerfile and pins the uv base image to an exact version (0.11.29) instead of the floating python3.12-alpine tag. Drops deprecated caller inputs (enable_auto_version, push_on_main) and the release/pull_request_target triggers, sets workflow-level permissions instead of a job-level block on the reusable caller, and onboards renovate.